### PR TITLE
Restructure service definitions for Symfony 3 compatibility

### DIFF
--- a/DependencyInjection/Compiler/ReCaptchaValidatorPass.php
+++ b/DependencyInjection/Compiler/ReCaptchaValidatorPass.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the DSReCaptcha Bundle.
+ *
+ * (c) Ilya Pokamestov <dario_swain@yahoo.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+namespace DS\ReCaptchaBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This compiler pass injects the Request object into the ReCaptchaValidator
+ */
+class ReCaptchaValidatorPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('ds_re_captcha.validator')) {
+            $definition = $container->getDefinition('ds_re_captcha.validator');
+
+            // The @request_stack service was added in Symfony 2.4
+            if ($container->hasDefinition('request_stack')) {
+                $definition->replaceArgument(0, new Reference('request_stack'));
+            } else {
+                $definition->replaceArgument(0, new Reference('request'));
+            }
+
+            // Scoped services are deprecated in Symfony 2.8 and removed in Symfony 3.0
+            if (method_exists($definition, 'setScope')) {
+                $definition->setScope('request');
+            }
+        }
+    }
+}

--- a/ReCaptchaBundle.php
+++ b/ReCaptchaBundle.php
@@ -11,6 +11,8 @@
 
 namespace DS\ReCaptchaBundle;
 
+use DS\ReCaptchaBundle\DependencyInjection\Compiler\ReCaptchaValidatorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -20,4 +22,10 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class ReCaptchaBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new ReCaptchaValidatorPass());
+    }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,18 +1,17 @@
 services:
     ds_re_captcha.validator:
         class: DS\Component\ReCaptchaValidator\Validator\ReCaptchaValidator
-        scope: request
         arguments:
-            request: @request
-            privateKey: "%re_captcha.private_key%"
-            driver: null
-            enabled: "%re_captcha.enabled%"
+            - # Either @request or @request_stack
+            - "%re_captcha.private_key%"
+            - null
+            - "%re_captcha.enabled%"
         tags:
             - { name: validator.constraint_validator, alias: ds_re_captcha.validator }
 
     ds_re_captcha.form.type:
         class: DS\Component\ReCaptchaValidator\Form\ReCaptchaType
-        arguments: ["%re_captcha.public_key%", %re_captcha.locale%]
+        arguments: ["%re_captcha.public_key%", "%re_captcha.locale%"]
         tags:
             - { name: form.type, alias: ds_re_captcha }
 


### PR DESCRIPTION
Will require https://github.com/DarioSwain/ReCaptchaValidator/pull/9 to be merged first otherwise there will be incompatibilities.

This PR updates the service definitions for Symfony 3 support, mainly:
- Ensures all YAML definitions are correctly quoted
- Scoped services were deprecated in Symfony 2.8 and removed in Symfony 3.0, adds the scope in a compiler pass if this support is present
- The `@request` service is removed in Symfony 3.0, adds support for injecting the `@request_stack` service when available.
