### PR TITLE
Allow updated version of ReCaptchaValidator component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "dario_swain/re-captcha-validator": "1.0.4"
+        "dario_swain/re-captcha-validator": "^1.0.4"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
This will allow the bundle to be pulled with a Symfony 3 compatible version of the component
